### PR TITLE
Make module components not optional

### DIFF
--- a/Viperit/Core/Module.swift
+++ b/Viperit/Core/Module.swift
@@ -16,7 +16,7 @@ public protocol ViperitModule {
     var storyboardName: String { get }
 }
 
-public extension RawRepresentable where Self: ViperitModule, RawValue == String {
+public extension ViperitModule where Self: RawRepresentable, Self.RawValue == String {
     var storyboardName: String {
         return rawValue
     }
@@ -24,11 +24,11 @@ public extension RawRepresentable where Self: ViperitModule, RawValue == String 
 
 //MARK: - Module
 public struct Module {
-    public fileprivate(set) var view: UserInterface!
-    public fileprivate(set) var interactor: Interactor!
-    public fileprivate(set) var presenter: Presenter!
-    public fileprivate(set) var router: Router!
-    public fileprivate(set) var displayData: DisplayData!
+    public fileprivate(set) var view: UserInterface
+    public fileprivate(set) var interactor: Interactor
+    public fileprivate(set) var presenter: Presenter
+    public fileprivate(set) var router: Router
+    public fileprivate(set) var displayData: DisplayData
     
     public static func build<T: RawRepresentable & ViperitModule>(_ module: T, bundle: Bundle = Bundle.main, deviceType: UIUserInterfaceIdiom? = nil) -> Module where T.RawValue == String {
         //Get class types

--- a/ViperitTests/ModuleTests.swift
+++ b/ViperitTests/ModuleTests.swift
@@ -55,13 +55,13 @@ class ModuleTests: XCTestCase {
         let p = module.presenter
         let r = module.router
         
-        XCTAssert(v?._presenter is SamplePresenter)
-        XCTAssert(v?._displayData is SampleDisplayData)
-        XCTAssert(i?._presenter is SamplePresenter)
-        XCTAssert(p?._view is SampleView)
-        XCTAssert(p?._router is SampleRouter)
-        XCTAssert(r?._presenter is SamplePresenter)
-        XCTAssert(r?._view is SampleView)        
+        XCTAssert(v._presenter is SamplePresenter)
+        XCTAssert(v._displayData is SampleDisplayData)
+        XCTAssert(i._presenter is SamplePresenter)
+        XCTAssert(p._view is SampleView)
+        XCTAssert(p._router is SampleRouter)
+        XCTAssert(r._presenter is SamplePresenter)
+        XCTAssert(r._view is SampleView)
     }
     
     func testMockViewInjection() {
@@ -75,10 +75,10 @@ class ModuleTests: XCTestCase {
         let r = module.router
         
         XCTAssert(v is MockView)
-        XCTAssert(v?._presenter is SamplePresenter)
-        XCTAssert(v?._displayData is SampleDisplayData)
-        XCTAssert(p?._view is MockView)
-        XCTAssert(r?._view is MockView)
+        XCTAssert(v._presenter is SamplePresenter)
+        XCTAssert(v._displayData is SampleDisplayData)
+        XCTAssert(p._view is MockView)
+        XCTAssert(r._view is MockView)
     }
     
     func testMockPresenterInjection() {
@@ -93,12 +93,12 @@ class ModuleTests: XCTestCase {
         let r = module.router
         
         XCTAssert(p is MockPresenter)
-        XCTAssert(p?._view is SampleView)
-        XCTAssert(p?._interactor is SampleInteractor)
-        XCTAssert(p?._router is SampleRouter)
-        XCTAssert(r?._presenter is MockPresenter)
-        XCTAssert(v?._presenter is MockPresenter)
-        XCTAssert(i?._presenter is MockPresenter)
+        XCTAssert(p._view is SampleView)
+        XCTAssert(p._interactor is SampleInteractor)
+        XCTAssert(p._router is SampleRouter)
+        XCTAssert(r._presenter is MockPresenter)
+        XCTAssert(v._presenter is MockPresenter)
+        XCTAssert(i._presenter is MockPresenter)
     }
     
     func testMockInteractorInjection() {
@@ -111,8 +111,8 @@ class ModuleTests: XCTestCase {
         let p = module.presenter
         
         XCTAssert(i is MockInteractor)
-        XCTAssert(i?._presenter is SamplePresenter)
-        XCTAssert(p?._interactor is MockInteractor)
+        XCTAssert(i._presenter is SamplePresenter)
+        XCTAssert(p._interactor is MockInteractor)
     }
     
     func testMockRouterInjection() {
@@ -125,7 +125,7 @@ class ModuleTests: XCTestCase {
         let r = module.router
         
         XCTAssert(r is MockRouter)
-        XCTAssert(r?._presenter is SamplePresenter)
-        XCTAssert(p?._router is MockRouter)
+        XCTAssert(r._presenter is SamplePresenter)
+        XCTAssert(p._router is MockRouter)
     }
 }


### PR DESCRIPTION
We can assure that after running Module.build() all dependencies will be set, so no need for declaring components as unwrapped optionals. Taking advantage of using a struct instead of a class. Also extended ViperitModule protocol instead of extending RawRepresentable to make it more readable.