### PR TITLE
Update Core for accept TableViewController and TabBarController

### DIFF
--- a/Viperit.xcodeproj/project.pbxproj
+++ b/Viperit.xcodeproj/project.pbxproj
@@ -63,6 +63,9 @@
 		53D3AF211E07109D0099A464 /* SecondViewPad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D3AF101E07109D0099A464 /* SecondViewPad.swift */; };
 		53D3AF321E0711000099A464 /* HomeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D3AF311E0711000099A464 /* HomeTests.swift */; };
 		53F14AA41E7BF3D400E61452 /* Viperit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5367C0CF1DD7C68D005B6676 /* Viperit.framework */; };
+		9C7819FA221EE7E100D47E45 /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7819F9221EE7E100D47E45 /* UINavigationController+.swift */; };
+		9C7819FE221EEB3D00D47E45 /* AppModules.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7819FD221EEB3D00D47E45 /* AppModules.swift */; };
+		9C781A00221EECAD00D47E45 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7819FF221EECAD00D47E45 /* UIViewController+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -158,6 +161,9 @@
 		53D3AF261E0710E90099A464 /* ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		53D3AF311E0711000099A464 /* HomeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeTests.swift; sourceTree = "<group>"; };
 		53D3AF331E0711AE0099A464 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9C7819F9221EE7E100D47E45 /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
+		9C7819FD221EEB3D00D47E45 /* AppModules.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppModules.swift; sourceTree = "<group>"; };
+		9C7819FF221EECAD00D47E45 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -252,15 +258,16 @@
 		53532C5C1DD50DDF00088AAC /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				5372505D1EF13500007F3A10 /* ViperitModule.swift */,
 				53532C641DD50DDF00088AAC /* ViperitError.swift */,
 				53532C631DD50DDF00088AAC /* ViperComponent.swift */,
-				5372505D1EF13500007F3A10 /* ViperitModule.swift */,
-				53532C5F1DD50DDF00088AAC /* Module.swift */,
 				53532C621DD50DDF00088AAC /* UserInterface.swift */,
+				53532C5F1DD50DDF00088AAC /* Module.swift */,
 				53532C5D1DD50DDF00088AAC /* DisplayData.swift */,
 				53532C5E1DD50DDF00088AAC /* Interactor.swift */,
 				53532C601DD50DDF00088AAC /* Presenter.swift */,
 				53532C611DD50DDF00088AAC /* Router.swift */,
+				9C7819FD221EEB3D00D47E45 /* AppModules.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -320,6 +327,8 @@
 			isa = PBXGroup;
 			children = (
 				53D3AEF51E0709A80099A464 /* String+.swift */,
+				9C7819F9221EE7E100D47E45 /* UINavigationController+.swift */,
+				9C7819FF221EECAD00D47E45 /* UIViewController+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -614,13 +623,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9C7819FA221EE7E100D47E45 /* UINavigationController+.swift in Sources */,
 				5367C0DC1DD7C69E005B6676 /* ViperitError.swift in Sources */,
 				53D3AEF61E0709A80099A464 /* String+.swift in Sources */,
 				5367C0DD1DD7C69E005B6676 /* ViperComponent.swift in Sources */,
 				5367C0DE1DD7C69E005B6676 /* Module.swift in Sources */,
+				9C7819FE221EEB3D00D47E45 /* AppModules.swift in Sources */,
 				5367C0DF1DD7C69E005B6676 /* UserInterface.swift in Sources */,
 				5367C0E01DD7C69E005B6676 /* DisplayData.swift in Sources */,
 				5367C0E11DD7C69E005B6676 /* Interactor.swift in Sources */,
+				9C781A00221EECAD00D47E45 /* UIViewController+.swift in Sources */,
 				5367C0E21DD7C69E005B6676 /* Presenter.swift in Sources */,
 				5367C0E31DD7C69E005B6676 /* Router.swift in Sources */,
 				5372505E1EF13500007F3A10 /* ViperitModule.swift in Sources */,

--- a/Viperit/Core/AppModules.swift
+++ b/Viperit/Core/AppModules.swift
@@ -1,0 +1,15 @@
+//
+//  AppModules.swift
+//  Viperit
+//
+//  Created by Daniel Griso Filho on 21/02/19.
+//  Copyright © 2019 Ferran Abelló. All rights reserved.
+//
+
+import Foundation
+
+//MARK: - Application modules
+public enum AppModules: String, ViperitModule {
+    //TODO: - Insert the views here like this
+    case <#ScreenNameHere#>
+}

--- a/Viperit/Core/Presenter.swift
+++ b/Viperit/Core/Presenter.swift
@@ -8,7 +8,7 @@
 
 public protocol PresenterProtocol {
     var _interactor: Interactor! { get set }
-    var _view: UserInterface! { get set }
+    var _view: Any! { get set }
     var _router: Router! { get set }
         
     func setupView(data: Any)
@@ -21,7 +21,7 @@ public protocol PresenterProtocol {
 
 open class Presenter: PresenterProtocol {
     public var _interactor: Interactor!
-    public weak var _view: UserInterface!
+    public var _view: Any!
     public var _router: Router!
     
     required public init() { }

--- a/Viperit/Core/UserInterface.swift
+++ b/Viperit/Core/UserInterface.swift
@@ -10,13 +10,10 @@ import UIKit
 
 public protocol UserInterfaceProtocol {
     var _presenter: Presenter! { get set }
-    var _displayData: DisplayData! { get set }
 }
-
 
 open class UserInterface: UIViewController, UserInterfaceProtocol {
     public var _presenter: Presenter!
-    public var _displayData: DisplayData!
     
     open override func viewDidLoad() {
         super.viewDidLoad()
@@ -26,6 +23,54 @@ open class UserInterface: UIViewController, UserInterfaceProtocol {
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         _presenter.viewIsAboutToAppear()
+        self.setNeedsStatusBarAppearanceUpdate()
+    }
+    
+    open override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        _presenter.viewHasAppeared()
+    }
+    
+    open override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        _presenter.viewIsAboutToDisappear()
+    }
+    
+    open override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        _presenter.viewHasDisappeared()
+    }
+}
+
+open class TabUserInterface: UITabBarController, UserInterfaceProtocol {
+    
+    public var _presenter: Presenter!
+    
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        _presenter.viewIsAboutToAppear()
+    }
+    
+    open override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        _presenter.viewHasAppeared()
+    }
+    
+}
+
+open class TableUserInterface: UITableViewController, UserInterfaceProtocol {
+    
+    public var _presenter: Presenter!
+    
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+        _presenter.viewHasLoaded()
+    }
+    
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        _presenter.viewIsAboutToAppear()
+        self.setNeedsStatusBarAppearanceUpdate()
     }
     
     open override func viewDidAppear(_ animated: Bool) {

--- a/Viperit/Core/ViperComponent.swift
+++ b/Viperit/Core/ViperComponent.swift
@@ -13,5 +13,4 @@ internal enum ViperComponent: String {
     case interactor
     case presenter
     case router
-    case displayData
 }

--- a/Viperit/Core/ViperitModule.swift
+++ b/Viperit/Core/ViperitModule.swift
@@ -19,19 +19,25 @@ public enum ViperitViewType {
 public protocol ViperitModule {
     var viewType: ViperitViewType { get }
     var viewName: String { get }
-    func build(bundle: Bundle, deviceType: UIUserInterfaceIdiom?) -> Module
+    func build(bundle: Bundle, deviceType: UIUserInterfaceIdiom?, sbModule: AppModules?) -> Module
 }
 
 public extension ViperitModule where Self: RawRepresentable, Self.RawValue == String {
     var viewType: ViperitViewType {
-        return .storyboard
+        if let _ = Bundle.main.path(forResource: viewName.uppercasedFirst, ofType: "storyboardc") {
+            return .storyboard
+        }
+        if Bundle.main.path(forResource: viewName.uppercasedFirst, ofType: "nib") != nil  {
+            return .nib
+        }
+        return .code
     }
     
     var viewName: String {
         return rawValue
     }
     
-    func build(bundle: Bundle = Bundle.main, deviceType: UIUserInterfaceIdiom? = nil) -> Module {
-        return Module.build(self, bundle: bundle, deviceType: deviceType)
+    func build(bundle: Bundle = Bundle.main, deviceType: UIUserInterfaceIdiom? = nil, sbModule: AppModules? = nil) -> Module {
+        return Module.build(self, bundle: bundle, deviceType: deviceType, storyboardModule: sbModule)
     }
 }

--- a/Viperit/Extensions/String+.swift
+++ b/Viperit/Extensions/String+.swift
@@ -12,8 +12,13 @@ extension String {
     var first: String {
         return String(prefix(1))
     }
+    
     var uppercasedFirst: String {
         return first.uppercased() + String(dropFirst())
+    }
+    
+    func localized() -> String {
+        return NSLocalizedString(self, comment: "")
     }
 }
 

--- a/Viperit/Extensions/UINavigationController+.swift
+++ b/Viperit/Extensions/UINavigationController+.swift
@@ -1,0 +1,33 @@
+//
+//  UINavigationController+.swift
+//  Viperit
+//
+//  Created by Daniel Griso Filho on 21/02/19.
+//  Copyright © 2019 Ferran Abelló. All rights reserved.
+//
+
+import UIKit
+
+extension UINavigationController {
+    
+    func popViewController(animated: Bool, completion: @escaping (() -> Void)) {
+        popViewController(animated: animated)
+        doAfterAnimatingTransition(animated: animated, completion: completion)
+    }
+    
+    private func doAfterAnimatingTransition(animated: Bool, completion: @escaping (() -> Void)) {
+        if let coordinator = transitionCoordinator, animated {
+            coordinator.animate(alongsideTransition: nil, completion: { _ in
+                completion()
+            })
+        } else {
+            DispatchQueue.main.async {
+                completion()
+            }
+        }
+    }
+    
+    open override var preferredStatusBarStyle: UIStatusBarStyle {
+        return topViewController?.preferredStatusBarStyle ?? .default
+    }
+}

--- a/Viperit/Extensions/UIViewController+.swift
+++ b/Viperit/Extensions/UIViewController+.swift
@@ -1,0 +1,16 @@
+//
+//  UIViewController+.swift
+//  Viperit
+//
+//  Created by Daniel Griso Filho on 21/02/19.
+//  Copyright © 2019 Ferran Abelló. All rights reserved.
+//
+
+import UIKit
+
+extension UIViewController {
+    
+    func embedInNavigationController() -> UINavigationController {
+        return UINavigationController(rootViewController: self)
+    }
+}


### PR DESCRIPTION
Removed Display Data, is better if you create a viewModel;
Now you can inherit from TabBarController and UITableViewController;
You can have more than one storyboard into the storyboard file, using the sbModule to routing to the screen;
Now you know when you are using storyboard, nib and viewCode;
Add routers to TabBar;
Extension String know to localize the string;
Extension UINavigationController to pop view and set the preferred Status Bar Style
Extension UIViewController to embed navigation