### PR TITLE
Migration to Swift 6.

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Viperit.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Viperit.xcscheme
@@ -1,26 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1640"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Viperit"
+               BuildableName = "Viperit"
+               BlueprintName = "Viperit"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldAutocreateTestPlan = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "53532C4B1DD50BD200088AAC"
-               BuildableName = "ViperitTests.xctest"
+               BlueprintIdentifier = "ViperitTests"
+               BuildableName = "ViperitTests"
                BlueprintName = "ViperitTests"
-               ReferencedContainer = "container:Viperit.xcodeproj">
+               ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
       </Testables>
@@ -42,6 +59,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Viperit"
+            BuildableName = "Viperit"
+            BlueprintName = "Viperit"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Viperit
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Example/modules/Home/HomeView.swift
+++ b/Example/modules/Home/HomeView.swift
@@ -11,6 +11,7 @@ import Viperit
 
 
 //MARK: - Public Interface Protocol
+@MainActor
 protocol HomeViewInterface {
     func showLoading()
     func showInfo(message: String)

--- a/ExampleTests/HomeTests.swift
+++ b/ExampleTests/HomeTests.swift
@@ -27,38 +27,46 @@ class HomeMockView: UserInterface, HomeViewInterface {
     }
 }
 
-class HomeTests: XCTestCase {
-    
-    var view: HomeMockView!
-    var presenter: HomePresenter!
-    
-    override func setUp() {
-        super.setUp()
-        var mod = AppModules.home.build()
-        view = HomeMockView()
-        view.expectation = expectation(description: "Test expectation description")
-        presenter = mod.presenter as? HomePresenter
-        mod.injectMock(view: view)
+struct HomeMockModuleComponents {
+    let view: HomeMockView
+    let presenter: HomePresenter
+}
+
+@MainActor
+class HomeTests: XCTestCase, Sendable {
+
+    private(set) var mockModuleComponents: HomeMockModuleComponents!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await buildMockComponents()
     }
-    
+
+    private func buildMockComponents() async {
+        var mod = AppModules.home.build()
+        mockModuleComponents = .init(view: HomeMockView(), presenter: (mod.presenter as? HomePresenter)!)
+        mockModuleComponents.view.expectation = expectation(description: "Test expectation description")
+        mod.injectMock(view: mockModuleComponents.view)
+    }
+
     func expect(timeout: TimeInterval = 5, errorMessage: String = "TIMEOUT") {
         waitForExpectations(timeout: 5) { error in
             guard error != nil else { return }
             XCTFail(errorMessage)
         }
     }
-    
+
     func testShowInfo1() {
         print("---RUNNING TEST1---")
-        view.expectedMessage = "CONTENT_LOADED"
-        presenter.loadContent()
+        mockModuleComponents.view.expectedMessage = "CONTENT_LOADED"
+        mockModuleComponents.presenter.loadContent()
         expect()
     }
-    
+
     func testShowInfo2() {
         print("---RUNNING TEST2---")
-        view.expectedMessage = "CONTENT_LOADED"
-        presenter.loadContent()
+        mockModuleComponents.view.expectedMessage = "CONTENT_LOADED"
+        mockModuleComponents.presenter.loadContent()
         expect()
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,9 @@
-// swift-tools-version:5.0
+// swift-tools-version:6.0
 import PackageDescription
 
 let package = Package(
     name: "Viperit",
-    platforms: [.iOS("11.0")],
+    platforms: [.iOS("12.0")],
     products: [
         .library(name: "Viperit", targets: ["Viperit"])
     ],

--- a/Viperit.podspec
+++ b/Viperit.podspec
@@ -15,7 +15,7 @@ Viper Framework for iOS to implement VIPER architecture in an easy way
   s.source           = { :git => 'https://github.com/ferranabello/Viperit.git', :tag => s.version.to_s }
   s.weak_framework = 'SwiftUI'
   s.social_media_url = 'https://twitter.com/acferran'
-  s.swift_version = '5'
+  s.swift_version = '6'
 
   s.ios.deployment_target = '12.0'
   s.source_files = 'Viperit/**/*.swift'

--- a/Viperit.xcodeproj/project.pbxproj
+++ b/Viperit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -639,8 +639,9 @@
 		53532C301DD50BD200088AAC /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 0820;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1640;
 				ORGANIZATIONNAME = "Ferran Abelló";
 				TargetAttributes = {
 					53532C371DD50BD200088AAC = {
@@ -868,6 +869,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -900,6 +902,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -929,6 +932,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -961,6 +965,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -972,7 +977,8 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -982,66 +988,76 @@
 		53532C561DD50BD200088AAC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.acferran.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
 		53532C571DD50BD200088AAC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.acferran.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};
 		53532C591DD50BD200088AAC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = "";
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = NO;
 				INFOPLIST_FILE = ViperitTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.acferran.ViperitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
 		53532C5A1DD50BD200088AAC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = "";
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = NO;
 				INFOPLIST_FILE = ViperitTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.acferran.ViperitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};
@@ -1057,11 +1073,17 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = Viperit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MARKETING_VERSION = 1.5.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,
@@ -1070,7 +1092,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1088,11 +1110,17 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = Viperit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MARKETING_VERSION = 1.5.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,
@@ -1101,7 +1129,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1114,10 +1142,14 @@
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ExampleTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.acferran.ExampleTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
 			name = Debug;
@@ -1129,10 +1161,14 @@
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ExampleTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.acferran.ExampleTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
 			name = Release;

--- a/Viperit.xcodeproj/xcshareddata/xcschemes/Viperit.xcscheme
+++ b/Viperit.xcodeproj/xcshareddata/xcschemes/Viperit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1640"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Viperit/Core/Module.swift
+++ b/Viperit/Core/Module.swift
@@ -11,11 +11,13 @@ import UIKit
 
 private let kTabletSuffix = "Pad"
 
+@MainActor
 public protocol ViperitComponent {
     init()
 }
 
 //MARK: - Module
+@MainActor
 public struct Module {
     public private(set) var view: UserInterfaceProtocol
     public private(set) var interactor: InteractorProtocol
@@ -121,6 +123,7 @@ extension Module {
 //MARK: - Private Extension for Application Module generic enum
 extension RawRepresentable where RawValue == String {
 
+    @MainActor
     func classForViperComponent(_ component: ViperComponent, bundle: Bundle, deviceType: UIUserInterfaceIdiom? = nil) -> Swift.AnyClass? {
         let className = rawValue.uppercasedFirst + component.rawValue.uppercasedFirst
         let bundleName = safeString(bundle.infoDictionary?["CFBundleName"])

--- a/Viperit/Core/Router.swift
+++ b/Viperit/Core/Router.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@MainActor
 public protocol RouterProtocol: ViperitComponent {
     var _presenter: PresenterProtocol! { get set }
     var _view: UserInterfaceProtocol! { get }

--- a/Viperit/Core/UserInterface.swift
+++ b/Viperit/Core/UserInterface.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@MainActor
 public protocol UserInterfaceProtocol: AnyObject {
     var _presenter: PresenterProtocol! { get set }
     var _displayData: DisplayData? { get set }

--- a/Viperit/Core/ViperitModule.swift
+++ b/Viperit/Core/ViperitModule.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2017 Ferran Abelló. All rights reserved.
 //
 
+import Combine
 import UIKit
 
 #if canImport(SwiftUI)
@@ -22,6 +23,7 @@ public enum ViperitViewType {
 }
 
 //MARK: - Viperit Module Protocol
+@MainActor
 public protocol ViperitModule {
     var viewType: ViperitViewType { get }
     var viewName: String { get }

--- a/ViperitTests/ModuleTests.swift
+++ b/ViperitTests/ModuleTests.swift
@@ -14,6 +14,7 @@ private class MockPresenter: Presenter {}
 private class MockInteractor: Interactor {}
 private class MockRouter: Router {}
 
+@MainActor
 class ModuleTests: XCTestCase {
     private lazy var testBundle = Bundle(for: SampleRouter.self)
     

--- a/ViperitTests/PresenterTests.swift
+++ b/ViperitTests/PresenterTests.swift
@@ -66,6 +66,7 @@ private class MockPresenter: Presenter, SamplePresenterInterface {
 }
 
 //MARK: - Presenter Tests
+@MainActor
 class PresenterTests: XCTestCase {
     private func createTestModuleWithMockPresenter(methodToTest: String) -> Module {
         var module = TestModules.sample.build(bundle: Bundle(for: SampleRouter.self))

--- a/ViperitTests/RouterTests.swift
+++ b/ViperitTests/RouterTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 import Viperit
 
+@MainActor
 class RouterTests: XCTestCase {
     private func createTestModule(forTablet: Bool = false) -> Module {
         let deviceType: UIUserInterfaceIdiom = forTablet ? .pad : .phone


### PR DESCRIPTION
Good morning:

According to the question asked in issue #132, I've tried to make the migration of Viperit to Swift 6.
Because the module components are coupled to UIViewController and UIViewController is isolated to MainActor, I've also isolated them.

Also, the setUp method for testing Example project has been changed because it's required to use the async variant of setUp (based on the changes made).

After adding those changes, breaking changes are rosen, because all already created Viperit-based modules must be modified and provide compliance to the data isolation of its parent classes (maybe there's a way to provide retro-compatibility and adding a warning but I don't know yet if it's possible).

If anyone can provide some feedback when possible it would be good.

Best regards.